### PR TITLE
Chore: Use theme provider instead of direct variables.

### DIFF
--- a/layouts/Base/index.tsx
+++ b/layouts/Base/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import Head from 'next/head'
+import { ThemeProvider } from 'styled-components'
 import GlobalStyle from 'styles/global'
+import theme from 'styles/theme'
 
 type PageType = {
   title?: string
@@ -13,7 +15,7 @@ const Page: React.FC<PageType> = ({
   description,
   children,
 }: PageType) => (
-  <>
+  <ThemeProvider theme={theme}>
     <GlobalStyle />
     <Head>
       <title>{title}</title>
@@ -22,7 +24,7 @@ const Page: React.FC<PageType> = ({
       <link rel='icon' href='/favicon.ico' />
     </Head>
     {children}
-  </>
+  </ThemeProvider>
 )
 
 Page.defaultProps = {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,7 +5,7 @@ import { H1 } from 'styles/typography'
 const Home: React.FC = () => {
   return (
     <Layout>
-      <H1>Hello</H1>
+      <H1 light>Hello</H1>
     </Layout>
   )
 }

--- a/styles/colors.ts
+++ b/styles/colors.ts
@@ -12,11 +12,6 @@ export const xLightGray = gray1
 export const light = white
 export const xLight = gray1
 export const dark = black
-export const primary = blue
 export const accent = blue
 export const lightBorder = `1px solid ${lightGray}`
 export const featured = '#E95645'
-export const linearGradient =
-  'linear-gradient(-90deg, rgba(0,0,0,0) 20%, rgba(0,0,0, 1))'
-export const linearGradientMobile =
-  'linear-gradient(-90deg, rgba(0,0,0,0.5) 20%, rgba(0,0,0, 1))'

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,0 +1,64 @@
+import * as Colors from 'styles/colors'
+import * as Spacing from 'styles/spacing'
+import fontScale from 'styles/fontScale'
+
+interface Theme {
+  colors: {
+    accent: string
+    base: string
+    light: string
+    complement: string
+  }
+  borders: {
+    light: string
+  }
+  gradients: {
+    linear: string
+    linearMobile: string
+  }
+  spacings: {
+    defaultGridGap: string
+  }
+  breakpoints: {
+    small: string
+  }
+  fontScale: {
+    h00: string
+    h0: string
+    h1: string
+    h2: string
+    h3: string
+    h4: string
+    h5: string
+    h6: string
+    base: string
+  }
+}
+
+const theme: Theme = {
+  colors: {
+    accent: Colors.blue,
+    base: Colors.black,
+    light: Colors.xLightGray,
+    complement: Colors.magenta,
+  },
+  borders: {
+    light: '1px solid ${Colors.lightGray}',
+  },
+  gradients: {
+    linear: 'linear-gradient(-90deg, rgba(0,0,0,0) 20%, rgba(0,0,0, 1))',
+    linearMobile:
+      'linear-gradient(-90deg, rgba(0,0,0,0.5) 20%, rgba(0,0,0, 1))',
+  },
+  spacings: {
+    defaultGridGap: '0.5rem',
+  },
+  breakpoints: {
+    small: Spacing.breakpoint,
+  },
+  fontScale: {
+    ...fontScale,
+  },
+}
+
+export default theme

--- a/styles/typography.ts
+++ b/styles/typography.ts
@@ -1,138 +1,62 @@
 import styled, { css } from 'styled-components'
-import { light, featured, dark, xLightGray, accent } from './colors'
-import { View } from './primitives'
-import { headerFont, baseFont, accentFont, accompanyingFont } from './fonts'
-import fontScale from './fontScale'
+import { headerFont, baseFont } from './fonts'
 
 interface Heading {
   light?: boolean
   typeface?: boolean
   accent?: boolean
+  lowercase?: boolean
 }
 
-const headerStyles = css<{ lowercase?: boolean }>`
-  text-transform: uppercase;
-  color: ${dark};
+const headerStyles = css<Heading>`
   text-rendering: optimizeLegibility;
   font-family: ${headerFont};
-  ${props =>
-    props.lowercase &&
-    css`
-      text-transform: none;
-    `}
+  text-transform: ${props => (props.lowercase ? 'none' : 'uppercase')};
+  color: ${props =>
+    props.light ? props.theme.colors.light : props.theme.colors.base};
 `
 
 const H1 = styled.h1`
-  font-size: ${fontScale.h1};
+  font-size: ${props => props.theme.fontScale.h1};
   ${headerStyles};
 `
 
 const H2 = styled.h2`
-  font-size: ${fontScale.h2};
+  font-size: ${props => props.theme.fontScale.h2};
   ${headerStyles};
 `
 
 const H3 = styled.h3`
-  font-size: ${fontScale.h3};
+  font-size: ${props => props.theme.fontScale.h3};
   ${headerStyles};
 `
 
 const H4 = styled.h4`
-  font-size: ${fontScale.h4};
+  font-size: ${props => props.theme.fontScale.h4};
   ${headerStyles};
 `
 
 const H5 = styled.h5<Heading>`
-  font-size: ${fontScale.h5};
+  font-size: ${props => props.theme.fontScale.h5};
   ${headerStyles};
-  ${props =>
-    props.light &&
-    css`
-      color: ${xLightGray};
-    `}
-
-  ${props =>
-    props.typeface &&
-    css`
-      font-family: ${accentFont};
-      text-transform: uppercase;
-    `}
 `
 
 const H6 = styled.h6`
-  font-size: ${fontScale.h6};
+  font-size: ${props => props.theme.fontScale.h6};
   ${headerStyles};
 `
 
-const Featured = styled(View)`
-  background: ${featured};
-  display: inline-block;
-  color: ${light};
-  padding: 0.5em 1em;
-  line-height: 1em;
-  text-transform: uppercase;
-  font-size: ${fontScale.base};
-  font-family: ${accentFont};
-`
-
 const P = styled.p<Heading>`
-  font-size: ${fontScale.base};
+  font-size: ${props => props.theme.fontScale.base};
   line-height: 1.5em;
   font-family: ${baseFont};
 
   ${props =>
     props.light &&
     css`
-      color: ${xLightGray};
+      color: ${props => props.theme.colors.light};
       line-height: 1.75em;
     `}
-
-  ${props =>
-    props.typeface &&
-    css`
-      font-family: ${accentFont};
-    `}
 `
 
-const AccentH5 = styled.h5<Heading>`
-  font-size: ${fontScale.base};
-  ${headerStyles};
-  font-family: ${accentFont};
-
-  ${props =>
-    props.light &&
-    css`
-      color: ${xLightGray};
-    `};
-
-  ${props =>
-    props.accent &&
-    css`
-      color: ${accent};
-    `};
-`
-
-const AccompanyingText = styled(P)`
-  font-family: ${accompanyingFont};
-  color: ${xLightGray};
-  font-size: ${fontScale.h6};
-`
-
-const HeadingSmall = styled(H5)`
-  font-family: ${accompanyingFont};
-  color: ${xLightGray};
-`
-
-export {
-  H1,
-  H2,
-  H3,
-  H4,
-  H5,
-  H6,
-  P,
-  AccentH5,
-  AccompanyingText,
-  HeadingSmall,
-  Featured,
-}
+export { H1, H2, H3, H4, H5, H6, P }


### PR DESCRIPTION
## Reason for change

Replace direct imported variables with variables taken from the ThemeProvider both to improve DRYness and improve extensibility of themes in our base application.

## Changes

* add `ThemeProvider` in our `Base` layout.
* replace direct import variables in Typography with theme variables.
* removed some unused code.
